### PR TITLE
Kill ssh-agent after push

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -57,3 +57,6 @@ ssh-add deploy_key
 
 # Now that we're all set up, we can push.
 git push $SSH_REPO $TARGET_BRANCH
+
+# Kill the ssh-agent so it doesn't hang Travis-CI
+ssh-agent -k


### PR DESCRIPTION
Bug with Travis-CI keeps ssh-agent background process running and hangs the build.

https://github.com/travis-ci/travis-ci/issues/8082